### PR TITLE
Use shared button palette on product page

### DIFF
--- a/product.html
+++ b/product.html
@@ -13,7 +13,10 @@
       --card:#f6f8fa;
       --muted:#5b6b7b;
       --text:#0f1720;
-      --accent:#0b57d0;
+      --btn:#111;
+      --btnText:#fff;
+      --btnGhostBg:#ffffff;
+      --btnGhostText:#111;
       --border:#e5e7eb;
       --radius:16px;
       --maxw:1100px;
@@ -23,7 +26,10 @@
       --card:#11161d;
       --muted:#95a1af;
       --text:#eaf0f6;
-      --accent:#2f81f7;
+      --btn:#e9eef7;
+      --btnText:#0b0d12;
+      --btnGhostBg:#12151c;
+      --btnGhostText:#e9eef7;
       --border:#1b2530;
     }
     *{box-sizing:border-box}
@@ -37,9 +43,9 @@
     .container{max-width:var(--maxw);margin:0 auto;padding:16px}
     header{position:sticky;top:0;z-index:5;background:rgba(0,0,0,.25);backdrop-filter:blur(10px);border-bottom:1px solid var(--border)}
     .row{display:flex;gap:12px;align-items:center;justify-content:space-between}
-    .btn{display:inline-flex;align-items:center;gap:8px;padding:10px 14px;border-radius:12px;border:1px solid var(--border);background:linear-gradient(180deg, rgba(255,255,255,.04), rgba(255,255,255,.02));cursor:pointer;text-decoration:none;color:var(--text)}
+    .btn{display:inline-flex;align-items:center;gap:8px;padding:10px 14px;border-radius:12px;border:1px solid var(--border);background:var(--btnGhostBg);color:var(--btnGhostText);cursor:pointer;text-decoration:none}
     .btn.icon{width:40px;height:40px;padding:0}
-    .btn.primary{background:linear-gradient(180deg,var(--accent),#0d4bd7);color:#fff;border:none}
+    .btn.primary{background:var(--btn);border-color:var(--btn);color:var(--btnText)}
     .btn:hover{transform:translateY(-1px)}
     .card{background:linear-gradient(180deg, rgba(255,255,255,.03), rgba(255,255,255,.015));border:1px solid var(--border);border-radius:var(--radius)}
     .pad{padding:16px}
@@ -53,7 +59,7 @@
     .hero{width:100%;aspect-ratio:1/1;border-radius:12px;border:1px solid var(--border);object-fit:cover;background:#0a1016}
     .thumbs{display:flex;gap:8px;flex-wrap:wrap}
     .thumbs img{width:72px;height:72px;object-fit:cover;border-radius:10px;border:2px solid transparent;cursor:pointer}
-    .thumbs img.active{border-color:var(--accent)}
+    .thumbs img.active{border-color:var(--btn)}
     .desc{white-space:pre-wrap}
     .empty{padding:24px;border:1px dashed var(--border);border-radius:12px;text-align:center;color:var(--muted)}
     @media (max-width: 840px){ .grid{grid-template-columns:1fr; } }


### PR DESCRIPTION
## Summary
- Declare shared button color variables in product page for light and dark themes
- Replace blue gradients with theme variables for default and primary buttons
- Use button color for active gallery thumbnail borders

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f8d391984832eb60319be4ad8b39b