### PR TITLE
Add social links to shop config

### DIFF
--- a/shopConfig.json
+++ b/shopConfig.json
@@ -1,4 +1,9 @@
 {
+  "socials": [
+    {"label": "Avito", "url": "https://www.avito.ru/", "icon": "avito"},
+    {"label": "Telegram", "url": "https://t.me/bvbvbabab", "icon": "tg"},
+    {"label": "WhatsApp", "url": "https://wa.me/79831289090", "icon": "wa"}
+  ],
   "products": [
     {
       "title": "1 пара лыжных скрепок для гоночных лыж",


### PR DESCRIPTION
## Summary
- include Avito, Telegram, and WhatsApp social links in shop config so buttons render on main page

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2832366b0832e80b896b8d2d05960