### PR TITLE
Use square card images without blur on main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@ function renderGrid(items){
     const card=el(`
       <article class="card">
         <a href="product.html?slug=${encodeURIComponent(p.slug || slugify(p.title))}">
-          <div class="card-img" style="--img:url('${(p.images&&p.images[0])||''}')">
+          <div class="card-img">
             <img src="${(p.images&&p.images[0])||''}" alt="${p.title}" loading="lazy">
           </div>
           <div class="card-pad">

--- a/style.css
+++ b/style.css
@@ -82,9 +82,8 @@ header{
 }
 .card a{text-decoration:none;color:inherit}
 
-.card-img{position:relative;width:100%;aspect-ratio:16/11;overflow:hidden;background:var(--bg);--img:''}
-.card-img::before{content:'';position:absolute;inset:0;background-image:var(--img);background-size:cover;background-position:center;filter:blur(20px);transform:scale(1.1)}
-.card-img img{position:absolute;top:0;left:0;width:100%;height:100%;object-fit:contain}
+.card-img{position:relative;width:100%;aspect-ratio:1/1;overflow:hidden;background:var(--bg)}
+.card-img img{position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover}
 .card-pad{padding:14px}
 .badge{display:inline-flex;align-items:center;gap:6px;font-size:12px;
   padding:6px 10px;border:1px dashed var(--border);border-radius:999px;color:var(--muted)}


### PR DESCRIPTION
## Summary
- Show product card images in square frames without background blur
- Drop custom CSS variable from card grid

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a285d46ac8832e96088a3c103141a5