### PR TITLE
Add minimal package.json to prevent npm test errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "bvb.github.io",
+  "version": "1.0.0",
+  "private": true,
+  "description": "BVB static site",
+  "scripts": {
+    "test": "echo \"No tests specified\""
+  }
+}


### PR DESCRIPTION
## Summary
- add package.json with a no-op test script to avoid npm errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a28888fa0c832ebcfd27ebaef7487e